### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  
+
   def index
     @items = Item.all
     @items = Item.order("created_at DESC")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,7 @@
 class ItemsController < ApplicationController
 
   def index
-    @items = Item.all
     @items = Item.order("created_at DESC")
-    # @user = User.find(params[:user_id])
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  
   def index
     @items = Item.all
     @items = Item.order("created_at DESC")

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,60 +123,58 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <ul class='item-lists'>
+     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+      <% @items.each do |item| %>
+        <ul class='item-lists'>           
+         <li class='list'>
+          <%= link_to "#" do %>
+           <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-image" %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+             <%# 商品が売れていればsold outを表示しましょう %>
+             <%# if @item.has_key(:item) %>
+             <div class='sold-out'>
+             <span>Sold Out!!</span>
+             </div>
+             <%# end %>
+            <%# //商品が売れていればsold outを表示しましょう %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+           </div>
+           <div class='item-info'>
+              <h3 class='item-name'>
+               <%= item.name %>
+              </h3>
+              <div class='item-price'>
+               <span><%= item.price %>円<br><%= item.charge %></span>
+               <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
+         <% end %>
+        </li>
+       <% end %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>9,999,999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+               <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
-    </ul>
+         <% end %>
+       </li>
+        <%# //商品がある場合は表示されないようにしましょう %>
+      </ul>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -32,7 +32,8 @@
           <span class='reason-list-blue-text'>3分</span>
           ですぐに出品
         </h3>
-        <p class='reason-list-description'>
+        <p class='reason-list-
+        description'>
           スマホで入力するだけで簡単に出品できる！
         </p>
       </li>
@@ -125,38 +126,41 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <%@items.each do |item|%>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag  item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.charge.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <%end%>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+    <% if Item.nil? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,6 +178,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,57 +123,60 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-      <ul class='item-lists'>           
-        <% @items.each do |item| %>
-         <li class='list'>
-          <%= link_to "#" do %>
-           <div class='item-img-content'>
-            <%# <%= image_tag item.image, class: "item-image" %> %>
+    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <ul class='item-lists'>
 
-             <%# 商品が売れていればsold outを表示しましょう %>
-             <%# if @item.has_key(:item) %>
-             <div class='sold-out'>
-             <span>Sold Out!!</span>
-             </div>
-             <%# end %>            
-             <%# //商品が売れていればsold outを表示しましょう %>
-           </div>
-           <div class='item-info'>
-              <h3 class='item-name'>
-               <%= item.name %>
-              </h3>
-              <div class='item-price'>
-               <span><%= item.price %>円<br><%= item.charge %></span>
-               <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag "item-sample.png", class: "item-img" %>
+
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <%# //商品が売れていればsold outを表示しましょう %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= "商品名" %>
+          </h3>
+          <div class='item-price'>
+            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
             </div>
-           </div>
-          <% end %>
-         </li>
+          </div>
+        </div>
         <% end %>
-       <%# 商品がある場合は表示されないようにしましょう %
-        <li class='list'>
-          <%= link_to '#' do %>
-          <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> %>
-          <%# <div class='item-info'> %>
-            <%# <h3 class='item-name'> %>
-              <%# 商品を出品してね！ %>
-            <%# </h3> %>
-            <%# <div class='item-price'> %>
-              <%# <span>9,999,999円<br>(税込み)</span> %>
-              <%# <div class='star-btn'> %>
-                <%# <%= image_tag "star.png", class:"star-icon" %> %>
-               <%# <span class='star-count'>0</span> %>
-              <%# </div> %>
-            <%# </div> %>
-          <%# </div> %>
-         <%# <% end %> %>
-       <%# </li> %>
-        <%# //商品がある場合は表示されないようにしましょう %> %>
-      </ul>
+      </li>
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+      <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# /商品がない場合のダミー %>
+    </ul>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -160,7 +160,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-    <% if Item.nil? %>
+    <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,21 +124,20 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
      <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-      <% @items.each do |item| %>
-        <ul class='item-lists'>           
+      <ul class='item-lists'>           
+        <% @items.each do |item| %>
          <li class='list'>
           <%= link_to "#" do %>
            <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-image" %>
+            <%# <%= image_tag item.image, class: "item-image" %> %>
 
              <%# 商品が売れていればsold outを表示しましょう %>
              <%# if @item.has_key(:item) %>
              <div class='sold-out'>
              <span>Sold Out!!</span>
              </div>
-             <%# end %>
-            <%# //商品が売れていればsold outを表示しましょう %>
-
+             <%# end %>            
+             <%# //商品が売れていればsold outを表示しましょう %>
            </div>
            <div class='item-info'>
               <h3 class='item-name'>
@@ -151,29 +150,29 @@
                 <span class='star-count'>0</span>
               </div>
             </div>
-          </div>
-         <% end %>
-        </li>
-       <% end %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+           </div>
+          <% end %>
+         </li>
+        <% end %>
+       <%# 商品がある場合は表示されないようにしましょう %
         <li class='list'>
           <%= link_to '#' do %>
-          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              商品を出品してね！
-            </h3>
-            <div class='item-price'>
-              <span>9,999,999円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-               <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div>
-         <% end %>
-       </li>
-        <%# //商品がある場合は表示されないようにしましょう %>
+          <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> %>
+          <%# <div class='item-info'> %>
+            <%# <h3 class='item-name'> %>
+              <%# 商品を出品してね！ %>
+            <%# </h3> %>
+            <%# <div class='item-price'> %>
+              <%# <span>9,999,999円<br>(税込み)</span> %>
+              <%# <div class='star-btn'> %>
+                <%# <%= image_tag "star.png", class:"star-icon" %> %>
+               <%# <span class='star-count'>0</span> %>
+              <%# </div> %>
+            <%# </div> %>
+          <%# </div> %>
+         <%# <% end %> %>
+       <%# </li> %>
+        <%# //商品がある場合は表示されないようにしましょう %> %>
       </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create ]#:edit, #:update, #:show]
+  resources :items, only: [:index, :new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]#:edit, #:update, #:show]
+  resources :items, only: [:index, :new, :create ]#:edit, #:update, #:show]
 end


### PR DESCRIPTION
##What
商品一覧表示機能

##Why
- 画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
- 出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
-https://gyazo.com/d71a065f966c8d0817cfc5bd564bcbcd
- 売却済みの商品は、「sold out」の文字が表示されるようになっていること
- ログアウトした状態でも商品一覧ページを見ることができること
-https://gyazo.com/26ecf9667bf37be34612f0a8fac5a6c5


# 補足情報
「売却済みの商品は、『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能実装後に実装すること（商品購入機能実装前に商品一覧表示機能を実装する場合、コードレビュー時にこの機能は実装されていなくても良い。しかし、最終課題終了報告時に実装できていない場合、最終課題終了とはみなされない）。