### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,13 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def destory
+    @item = item.find(params[:id])
+    item.destroy
+  end
+
   def show
+    @item = Item.find(params[:id])
   end
 
   def create
@@ -24,5 +30,4 @@ class ItemsController < ApplicationController
   def item_params
    params.require(:item).permit(:name, :image, :price, :description, :category_id, :status_id, :charge_id, :deliverysource_id, :deliveryday_id ).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,10 +8,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
-  def destory
-    @item = item.find(params[:id])
-    item.destroy
-  end
+  #def destory
+   # @item = item.find(params[:id])
+    #item.destroy
+ # end
 
   def show
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,9 +8,8 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
-  #def show
-    #@item = Item.find(params[:id])
-  #end
+  def show
+  end
 
   def create
     @item = Item.new(item_params)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,13 +124,14 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%#if false%>
+   <%@items.each do |item|%>
+    <%= link_to '新規投稿商品', item_path(item.id), class: "subtitle" %>
     <ul class='item-lists'>
-      <%@items.each do |item|%>
 
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to item_path do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag  item.image, class: "item-img" %>
 
@@ -156,13 +157,14 @@
           <% end %>
         </li>
       <%end%>
+
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
     <% if @items.length == 0 %>
       <li class='list'>
-        <%= link_to item_path do %>
+        <%= link_to item_path(item.id) do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -182,6 +184,7 @@
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
+  <%# end %>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path do %>
           <div class='item-img-content'>
             <%= image_tag  item.image, class: "item-img" %>
 
@@ -162,7 +162,7 @@
       <%# 商品がある場合は表示されないようにしましょう %>
     <% if @items.length == 0 %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to item_path do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= item.neme %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,18 +16,18 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= item.charge.name %>
+        <%= @item.charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= item.description %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= user_id %></td>
+          <td class="detail-value"><%= @item.user %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= item.category.neme %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= item.status.neme %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= item.change.neme %></td>
+          <td class="detail-value"><%= @item.charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= item.deliverysource.neme %></td>
+          <td class="detail-value"><%= @item.deliverysource.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= item.deliveryday %></td>
+          <td class="detail-value"><%= @item.deliveryday %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= item.category.neme %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class='item-img-content'>
       <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+     <% if '商品が購入済み' %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+     <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -24,26 +26,23 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <% if user_signed_in?  %>
+       <% if current_user.id == @item.user_id %> 
+         <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+         <p class='or-text'>or</p>
+         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+         <% elsif @item.blank? %>
+         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <% end %>
 
-    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <div class="item-explain-box">
-      <span><%= @item.description %></span>
-    </div>
-    <table class="detail-table">
+     <div class="item-explain-box">
+       <span><%= @item.description %></span>
+     </div>
+     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -63,10 +62,11 @@
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.deliveryday %></td>
+          <td class="detail-value"><%= @item.deliveryday.name %></td>
         </tr>
       </tbody>
     </table>
+   <% end %>
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,47 +26,48 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-      <% if user_signed_in?  %>
+     <% if user_signed_in?  %>
        <% if current_user.id == @item.user_id %> 
-         <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-         <p class='or-text'>or</p>
-         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
-         <% elsif @item.blank? %>
-         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+          <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+          <p class='or-text'>or</p>
+          <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+        <% elsif '商品が出品中かどうか' %>
+          <%= link_to '購入画面に進む', @item.image ,class:"item-red-btn"%>
         <% end %>
+     <% end %>
+     
+       <div class="item-explain-box">
+        <span><%= @item.description %></span>
+       </div>
+       <table class="detail-table">
+        <tbody>
+          <tr>
+           <th class="detail-item">出品者</th>
+           <td class="detail-value"><%= @item.user.nickname %></td>
+          </tr>
+          <tr>
+           <th class="detail-item">カテゴリー</th>
+           <td class="detail-value"><%= @item.category.name %></td>
+          </tr>
+          <tr>
+           <th class="detail-item">商品の状態</th>
+           <td class="detail-value"><%= @item.status.name %></td>
+          </tr>
+          <tr>
+           <th class="detail-item">配送料の負担</th>
+           <td class="detail-value"><%= @item.charge.name %></td>
+          </tr>
+          <tr>
+           <th class="detail-item">発送元の地域</th>
+           <td class="detail-value"><%= @item.deliverysource.name %></td>
+          </tr>
+          <tr>
+           <th class="detail-item">発送日の目安</th>
+           <td class="detail-value"><%= @item.deliveryday.name %></td>
+          </tr>
+        </tbody>
+       </table>
 
-     <div class="item-explain-box">
-       <span><%= @item.description %></span>
-     </div>
-     <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.status.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.charge.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.deliverysource.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.deliveryday.name %></td>
-        </tr>
-      </tbody>
-    </table>
-   <% end %>
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= item.neme %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
@@ -19,15 +19,15 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= item.charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= user_id %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= item.category.neme %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= item.status.neme %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= item.change.neme %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= item.deliverysource.neme %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= item.deliveryday %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= item.category.neme %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show, :edit, :destroy]
 end


### PR DESCRIPTION
#what

-商品詳細機能

#why

-ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/9c0e189f01834f8c4cf3db0df78e7bae

-出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/da8e3f7ec25ebad2fdb4cb4843412e2a

-出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること

-商品出品時に登録した情報が見られるようになっていること

-画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。